### PR TITLE
Incorporate missing bed exception

### DIFF
--- a/backend/src/main/java/de/wirvsvirus/trackyourbed/excpetion/dependency/BedMissingException.java
+++ b/backend/src/main/java/de/wirvsvirus/trackyourbed/excpetion/dependency/BedMissingException.java
@@ -1,0 +1,13 @@
+package de.wirvsvirus.trackyourbed.excpetion.dependency;
+
+import static java.lang.String.format;
+
+
+import java.util.UUID;
+
+public class BedMissingException extends IllegalStateException{
+
+  public BedMissingException(final UUID missingId) {
+    super(format("Could not find department with ID %s", missingId));
+  }
+}

--- a/backend/src/main/java/de/wirvsvirus/trackyourbed/resource/ResourceExceptionHandler.java
+++ b/backend/src/main/java/de/wirvsvirus/trackyourbed/resource/ResourceExceptionHandler.java
@@ -1,5 +1,6 @@
 package de.wirvsvirus.trackyourbed.resource;
 
+import de.wirvsvirus.trackyourbed.excpetion.dependency.BedMissingException;
 import de.wirvsvirus.trackyourbed.excpetion.dependency.DepartmentMissingException;
 import de.wirvsvirus.trackyourbed.excpetion.dependency.HospitalMissingException;
 import de.wirvsvirus.trackyourbed.excpetion.dependency.InvalidBedStateException;
@@ -98,6 +99,13 @@ public class ResourceExceptionHandler {
   public ResponseEntity<HTTPError> mapHospitalMissingExceptionToBadRequestResponse(
       final HospitalMissingException e) {
     final HTTPError httpError = new HTTPError(ErrorCode.HOSPITAL_NOT_FOUND, e.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(httpError);
+  }
+
+  @ExceptionHandler(BedMissingException.class)
+  public ResponseEntity<HTTPError> mapBedMissingExceptionToBadRequestResponse(
+      final BedMissingException e){
+    final HTTPError httpError = new HTTPError(ErrorCode.BED_NOT_FOUND, e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(httpError);
   }
 

--- a/backend/src/test/java/de/wirvsvirus/trackyourbed/resource/ResourceExceptionHandlerTest.java
+++ b/backend/src/test/java/de/wirvsvirus/trackyourbed/resource/ResourceExceptionHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 
+import de.wirvsvirus.trackyourbed.excpetion.dependency.BedMissingException;
 import de.wirvsvirus.trackyourbed.excpetion.dependency.DepartmentMissingException;
 import de.wirvsvirus.trackyourbed.excpetion.dependency.HospitalMissingException;
 import de.wirvsvirus.trackyourbed.excpetion.dependency.InvalidBedStateException;
@@ -226,6 +227,24 @@ class ResourceExceptionHandlerTest {
     final HTTPError body = actual.getBody();
     assertNotNull(body);
     assertEquals(ErrorCode.HOSPITAL_NOT_FOUND, body.getErrorCode());
+    assertEquals(e.getMessage(), body.getErrorMessage());
+  }
+
+  @Test
+  @DisplayName("Should map BedMissingExceptions to BadRequestResponses.")
+  void shouldMapBedMissingExceptionToBadRequestResponse() {
+    //GIVEN
+    final BedMissingException e = new BedMissingException(UUID.randomUUID());
+
+    //WHEN
+    final ResponseEntity<HTTPError> actual =
+        new ResourceExceptionHandler().mapBedMissingExceptionToBadRequestResponse(e);
+
+    //THEN
+    assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode());
+    final HTTPError body = actual.getBody();
+    assertNotNull(body);
+    assertEquals(ErrorCode.BED_NOT_FOUND, body.getErrorCode());
     assertEquals(e.getMessage(), body.getErrorMessage());
   }
 


### PR DESCRIPTION
I had to generate a new MissingBedException, but not a new ErrorCode. Does this require some changes somewhere else? In our earlier discussion, we assumed, that a new Exception would not be necessary because we erroneously looked at NoSuchBedException. I then added the map to BadResponce and the test for that. Each is in a different commit. 